### PR TITLE
Recovery public key from signature

### DIFF
--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -607,7 +607,7 @@ impl EccCtx {
         }
     }
 
-    pub fn get_point_x(&self, x: &BigUint, neg: u8,) -> Result<Point, Sm2Error> {
+    pub fn get_point_x(&self, x: &BigUint, neg: u8) -> Result<Point, Sm2Error> {
         let ctx = &self.fctx;
 
         let x = FieldElem::from_biguint(x);
@@ -627,14 +627,16 @@ impl EccCtx {
 
     pub fn calc_pubkey(&self, s: &BigUint, r: &BigUint, p: &Point) -> Result<Point, Sm2Error> {
         // r = (p - sG) / (s + r)
-        let sg =  self.g_mul(s);
+        let sg = self.g_mul(s);
         let sg = self.neg(&sg);
         let num1 = self.add(p, &sg);
 
         let denominator = s + r;
         let num2 = self.inv_n(&denominator);
 
-        Ok(self.mul(&num2, &num1))
+        let p = self.mul(&num2, &num1);
+        let p = self.to_affine(&p);
+        self.new_point(&p.0, &p.1)
     }
 }
 

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -815,6 +815,29 @@ mod tests {
         let new_g = curve.bytes_to_point(&g_bytes_comp[..]).unwrap();
         assert!(curve.eq(&g, &new_g));
     }
+
+    #[test]
+    fn test_get_point_x() {
+        let curve = EccCtx::new();
+
+        // even
+        let g = curve.generator();
+        let (x, y) = curve.to_affine(&g);
+
+        let new_point = curve
+            .get_point_x(&x.to_biguint(), if y.is_even() { 0 } else { 1 })
+            .unwrap();
+        assert!(curve.eq(&g, &new_point));
+
+        // odd
+        let g = curve.double(&g);
+        let (x, y) = curve.to_affine(&g);
+
+        let new_point = curve
+            .get_point_x(&x.to_biguint(), if y.is_even() { 0 } else { 1 })
+            .unwrap();
+        assert!(curve.eq(&g, &new_point));
+    }
 }
 
 #[cfg(feature = "internal_benches")]

--- a/src/sm2/ecc.rs
+++ b/src/sm2/ecc.rs
@@ -607,7 +607,7 @@ impl EccCtx {
         }
     }
 
-    pub fn get_point_x(&self, x: &BigUint, neg: u8) -> Result<Point, Sm2Error> {
+    pub fn get_point_x(&self, x: &BigUint, neg: u32) -> Result<Point, Sm2Error> {
         let ctx = &self.fctx;
 
         let x = FieldElem::from_biguint(x);
@@ -618,7 +618,7 @@ impl EccCtx {
 
         let mut y = self.fctx.sqrt(&y_2)?;
 
-        if y.get_value(7) & 0x01 != neg as u32 {
+        if y.get_value(7) & 0x01 != neg {
             y = self.fctx.neg(&y);
         }
 
@@ -627,16 +627,13 @@ impl EccCtx {
 
     pub fn calc_pubkey(&self, s: &BigUint, r: &BigUint, p: &Point) -> Result<Point, Sm2Error> {
         // r = (p - sG) / (s + r)
-        let sg = self.g_mul(s);
-        let sg = self.neg(&sg);
+        let sg = self.neg(&self.g_mul(s));
         let num1 = self.add(p, &sg);
 
         let denominator = s + r;
         let num2 = self.inv_n(&denominator);
 
-        let p = self.mul(&num2, &num1);
-        let p = self.to_affine(&p);
-        self.new_point(&p.0, &p.1)
+        Ok(self.mul(&num2, &num1))
     }
 }
 

--- a/src/sm2/error.rs
+++ b/src/sm2/error.rs
@@ -21,6 +21,8 @@ pub enum Sm2Error {
     InvalidDer,
     InvalidPublic,
     InvalidPrivate,
+    InvalidMessage,
+    InvalidSignature,
 }
 
 impl ::std::fmt::Debug for Sm2Error {
@@ -37,6 +39,8 @@ impl From<Sm2Error> for &str {
             Sm2Error::InvalidDer => "invalid der",
             Sm2Error::InvalidPublic => "invalid public key",
             Sm2Error::InvalidPrivate => "invalid private key",
+            Sm2Error::InvalidMessage => "invalid message",
+            Sm2Error::InvalidSignature => "invalid signature",
         }
     }
 }
@@ -49,6 +53,8 @@ impl Display for Sm2Error {
             Sm2Error::InvalidDer => "invalid der",
             Sm2Error::InvalidPublic => "invalid public key",
             Sm2Error::InvalidPrivate => "invalid private key",
+            Sm2Error::InvalidMessage => "invalid message",
+            Sm2Error::InvalidSignature => "invalid signature",
         };
         write!(f, "{}", err_msg)
     }

--- a/src/sm2/mod.rs
+++ b/src/sm2/mod.rs
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 pub mod ecc;
-mod error;
+pub mod error;
 pub mod field;
 pub mod signature;

--- a/src/sm2/signature.rs
+++ b/src/sm2/signature.rs
@@ -629,15 +629,21 @@ mod tests {
         let x1 = ctx.ecdh_raw(&pk1, &sk2).unwrap();
         let secret1 = ctx
             .curve
-            .get_point_x(&BigUint::from_bytes_be(&x1.0), if x1.1 == 2 { 0 } else { 1 })
+            .get_point_x(
+                &BigUint::from_bytes_be(&x1.0),
+                if x1.1 == 2 { 0 } else { 1 },
+            )
             .unwrap();
 
         let x2 = ctx.ecdh_raw(&pk2, &sk1).unwrap();
         let secret2 = ctx
             .curve
-            .get_point_x(&BigUint::from_bytes_be(&x2.0), if x2.1 == 2 { 0 } else { 1 })
+            .get_point_x(
+                &BigUint::from_bytes_be(&x2.0),
+                if x2.1 == 2 { 0 } else { 1 },
+            )
             .unwrap();
-        
+
         assert_eq!(x1, x2);
         assert!(ctx.curve.eq(&secret1, &secret2));
     }

--- a/src/sm2/signature.rs
+++ b/src/sm2/signature.rs
@@ -258,7 +258,12 @@ impl SigCtx {
         }
     }
 
-    pub fn sign_raw_recoverable(&self, digest: &[u8], sk: &BigUint, k: BigUint) -> Result<(Signature, u8), Sm2Error> {
+    pub fn sign_raw_recoverable(
+        &self,
+        digest: &[u8],
+        sk: &BigUint,
+        k: BigUint,
+    ) -> Result<(Signature, u8), Sm2Error> {
         let curve = &self.curve;
         // Get the value "e", which is the hash of message and ID, EC parameters and public key
 
@@ -277,7 +282,11 @@ impl SigCtx {
         }
 
         let overflow = r_total.clone() / curve.get_n();
-        let recid = (if overflow.is_zero() { 0 } else { 1 << overflow.to_u8().unwrap() }) | (if y_1.is_even() { 0 } else { 1 });
+        let recid = (if overflow.is_zero() {
+            0
+        } else {
+            1 << overflow.to_u8().unwrap()
+        }) | (if y_1.is_even() { 0 } else { 1 });
 
         // s = (1 + sk)^-1 * (k - r * sk)
         let s1 = curve.inv_n(&(sk + BigUint::one()));
@@ -300,7 +309,7 @@ impl SigCtx {
         Err(Sm2Error::InvalidMessage)
     }
 
-    pub fn recover(&self, msg: &[u8], sig: &Signature, rec_id: u8,) -> Result<Point, Sm2Error> {
+    pub fn recover(&self, msg: &[u8], sig: &Signature, rec_id: u8) -> Result<Point, Sm2Error> {
         if sig.get_r().is_zero() || sig.get_s().is_zero() {
             return Err(Sm2Error::InvalidSignature);
         }

--- a/src/sm2/signature.rs
+++ b/src/sm2/signature.rs
@@ -115,6 +115,10 @@ impl SigCtx {
         }
     }
 
+    pub fn get_n(&self) -> &BigUint {
+        self.curve.get_n()
+    }
+
     pub fn hash(&self, id: &str, pk: &Point, msg: &[u8]) -> [u8; 32] {
         let curve = &self.curve;
 

--- a/src/sm2/signature.rs
+++ b/src/sm2/signature.rs
@@ -254,6 +254,71 @@ impl SigCtx {
         }
     }
 
+    pub fn sign_raw_recoverable(&self, digest: &[u8], sk: &BigUint, k: BigUint) -> Result<(Signature, u8), Sm2Error> {
+        let curve = &self.curve;
+        // Get the value "e", which is the hash of message and ID, EC parameters and public key
+
+        let e = BigUint::from_bytes_be(digest);
+
+        let p_1 = curve.g_mul(&k);
+        let (x_1, y_1) = curve.to_affine(&p_1);
+
+        let x_1 = x_1.to_biguint();
+
+        // r = e + x_1
+        let r_total = &e + x_1;
+        let r = r_total.clone() % curve.get_n();
+        if r == BigUint::zero() || &r + &k == *curve.get_n() {
+            return Err(Sm2Error::InvalidMessage);
+        }
+
+        let overflow = r_total.clone() / curve.get_n();
+        let recid = (if overflow.is_zero() { 0 } else { 1 << overflow.to_u8().unwrap() }) | (if y_1.is_even() { 0 } else { 1 });
+
+        // s = (1 + sk)^-1 * (k - r * sk)
+        let s1 = curve.inv_n(&(sk + BigUint::one()));
+
+        let mut s2_1 = &r * sk;
+        if s2_1 < k {
+            s2_1 += curve.get_n();
+        }
+        let mut s2 = s2_1 - k;
+        s2 %= curve.get_n();
+        let s2 = curve.get_n() - s2;
+
+        let s = (s1 * s2) % curve.get_n();
+
+        if s != BigUint::zero() {
+            // Output the signature (r, s)
+            return Ok((Signature { r, s }, recid));
+        }
+
+        Err(Sm2Error::InvalidMessage)
+    }
+
+    pub fn recover(&self, msg: &[u8], sig: &Signature, rec_id: u8,) -> Result<Point, Sm2Error> {
+        if sig.get_r().is_zero() || sig.get_s().is_zero() {
+            return Err(Sm2Error::InvalidSignature);
+        }
+
+        let curve = &self.curve;
+
+        let mut x = sig.get_r().clone();
+        if rec_id & 4 != 0 {
+            x = x + curve.get_n() + curve.get_n();
+        } else if rec_id & 2 != 0 {
+            x = x + curve.get_n();
+        }
+
+        let e = BigUint::from_bytes_be(msg);
+        x = x - e;
+
+        let p = curve.get_point_x(&x, rec_id & 1)?;
+
+        // r = (p - sG) / (s + r)
+        curve.calc_pubkey(sig.get_s(), sig.get_r(), &p)
+    }
+
     pub fn verify(&self, msg: &[u8], pk: &Point, sig: &Signature) -> bool {
         //Get hash value
         let digest = self.hash("1234567812345678", pk, msg);

--- a/src/sm2/signature.rs
+++ b/src/sm2/signature.rs
@@ -119,6 +119,14 @@ impl SigCtx {
         self.curve.get_n()
     }
 
+    pub fn new_point(&self, x: &FieldElem, y: &FieldElem) -> Result<Point, Sm2Error> {
+        self.curve.new_point(x, y)
+    }
+
+    pub fn bytes_to_point(&self, b: &[u8]) -> Result<Point, Sm2Error> {
+        self.curve.bytes_to_point(b)
+    }
+
     pub fn hash(&self, id: &str, pk: &Point, msg: &[u8]) -> [u8; 32] {
         let curve = &self.curve;
 
@@ -310,7 +318,7 @@ impl SigCtx {
     }
 
     pub fn recover(&self, msg: &[u8], sig: &Signature, rec_id: u8) -> Result<Point, Sm2Error> {
-        if sig.get_r().is_zero() || sig.get_s().is_zero() {
+        if sig.get_r().is_zero() || sig.get_s().is_zero() || rec_id > 5 {
             return Err(Sm2Error::InvalidSignature);
         }
 


### PR DESCRIPTION
Add algorithm to recovery public key from signature and additional recovery id. Reference the similar method from ECDSA: https://crypto.stackexchange.com/questions/18105/how-does-recovering-the-public-key-from-an-ecdsa-signature-work)